### PR TITLE
Addition of read_n function 

### DIFF
--- a/Button.h
+++ b/Button.h
@@ -8,7 +8,15 @@
 #define Button_H
 
 //-----------------------------------------------------------------------------------
-#include "WProgram.h" //It is very important to remember this! note that if you are using Arduino 1.0 IDE, change "WProgram.h" to "Arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
+#include "WProgram.h"
+#include "pins_arduino.h"
+#endif
+
 #include <MIDIBounce.h>
 
 /*! \brief Class for handling push button switches.

--- a/Led.h
+++ b/Led.h
@@ -8,7 +8,14 @@
 #define Led_H
 
 //-----------------------------------------------------------------------------------
-#include "WProgram.h" //It is very important to remember this! note that if you are using Arduino 1.0 IDE, change "WProgram.h" to "Arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
+#include "WProgram.h"
+#include "pins_arduino.h"
+#endif
 
 /*! \brief Class for handling single color LEDs.
 

--- a/MIDIBounce.cpp
+++ b/MIDIBounce.cpp
@@ -1,7 +1,15 @@
 
 // Please read MIDIBounce.h for information about the liscence and authors
 
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
 #include "WProgram.h"
+#include "pins_arduino.h"
+#endif
+
 #include "MIDIBounce.h"
 
 

--- a/Potentiometer.cpp
+++ b/Potentiometer.cpp
@@ -51,7 +51,7 @@ void Potentiometer::read(){
 }
 
 // read with relative noise canceling
-void Potentiometer::read_n(){
+void Potentiometer::read_n(int deviation = 8){
 
 	if(mapped){
 			tempRead=constrain(analogRead(pin),inMin,inMax);
@@ -61,7 +61,7 @@ void Potentiometer::read_n(){
 		tempRead=map(analogRead(pin), 0, 1023, 0, 127);
 		tempRead_n=analogRead(pin);
 
-	if (tempRead_n<=(lastValue_n-8) || tempRead_n>=(lastValue_n+8)) { //value changed
+	if (tempRead_n<=(lastValue_n-deviation) || tempRead_n>=(lastValue_n+deviation)) { //value changed
       midiCC(map(tempRead_n, 0, 1023, 0, 127), map(lastValue_n, 0, 1023, 0, 127));
     	lastValue_n=tempRead_n;
     }

--- a/Potentiometer.cpp
+++ b/Potentiometer.cpp
@@ -50,6 +50,24 @@ void Potentiometer::read(){
 	lastValue=tempRead;
 }
 
+// read with relative noise canceling
+void Potentiometer::read_n(){
+
+	if(mapped){
+			tempRead=constrain(analogRead(pin),inMin,inMax);
+			tempRead=map(tempRead,inMin,inMax,0,127);
+		}
+	else
+		tempRead=map(analogRead(pin), 0, 1023, 0, 127);
+		tempRead_n=analogRead(pin);
+
+	if (tempRead_n<=(lastValue_n-8) || tempRead_n>=(lastValue_n+8)) { //value changed
+      midiCC(map(tempRead_n, 0, 1023, 0, 127), map(lastValue_n, 0, 1023, 0, 127));
+    	lastValue_n=tempRead_n;
+    }
+	
+}
+
 // read
 void Potentiometer::readAvr(){
 	tempRead=0;

--- a/Potentiometer.h
+++ b/Potentiometer.h
@@ -8,7 +8,14 @@
 #define Potentiometer_H
 
 //-----------------------------------------------------------------------------------
-#include "WProgram.h" //It is very important to remember this! note that if you are using Arduino 1.0 IDE, change "WProgram.h" to "Arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
+#include "WProgram.h"
+#include "pins_arduino.h"
+#endif
 
 /*! \brief Class for handling faders, knobs or other analog input.
 
@@ -23,7 +30,9 @@ private:
 	bool mapped;
 	int inMin, inMax;
 	int lastValue;
+	int lastValue_n;
 	int tempRead;
+	int tempRead_n;
 	int readValues[3];
 	byte pin; // pin on teensy
 	byte channel; // midi channel
@@ -37,6 +46,7 @@ public:
 	~Potentiometer(); // destructor
 	void read(); //!< read the values and send a midi message if the fader or knob state changed. use in main loop
 	void readAvr(); //!< read the values for couple of iterations for a smoother value and send a midi message if the fader or knob state changed. use in main loop
+	void read_n(int); // !< Read with noise reduction 
 	int readValue(bool &changed); //!<  read and return the analog value, pass state change @param changed will beset to true if the state of the value changed from last time
 	int readValueAvr(bool &changed); //!<  read and return a smooth analog value, pass state change @param changed will beset to true if the state of the value changed from last time
 	void changeSecondary(bool s); //!< enable or disable the secondary super knob cc messages @param s enable super knob

--- a/RGBLed.h
+++ b/RGBLed.h
@@ -8,7 +8,14 @@
 #define RGBLed_H
 
 //-----------------------------------------------------------------------------------
-#include "WProgram.h" //It is very important to remember this! note that if you are using Arduino 1.0 IDE, change "WProgram.h" to "Arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
+#include "WProgram.h"
+#include "pins_arduino.h"
+#endif
 
 /*! \brief Class for handling tri color LEDs.
 

--- a/RGLed.h
+++ b/RGLed.h
@@ -8,7 +8,14 @@
 #define RGLed_H
 
 //-----------------------------------------------------------------------------------
-#include "WProgram.h" //It is very important to remember this! note that if you are using Arduino 1.0 IDE, change "WProgram.h" to "Arduino.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#elif defined(WIRING)
+#include "Wiring.h"
+#else
+#include "WProgram.h"
+#include "pins_arduino.h"
+#endif
 
 /*! \brief Class for handling bi color LEDs.
 


### PR DESCRIPTION
Added an additional function that might come in handy for people that are getting unstable potentiometer values (apparently a real problem if you are using manual wiring instead of PCB's).

The read_n function only sends out a new value if it deviates a certain amount of the previous value. The comparison is done before converting the 0-1023 reading to 0-127 causing no loss of resolution.
